### PR TITLE
Add client header option to requests (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This project is available at PyPI: [https://pypi.python.org/pypi/cachet-url-moni
 endpoint:
   url: http://www.google.com
   method: GET
+  header:
+    SOME-HEADER: SOME-VALUE
   timeout: 1 # seconds
   expectation:
     - type: HTTP_STATUS
@@ -44,6 +46,7 @@ frequency: 30
 - **endpoint**, the configuration about the URL that will be monitored.
     - **url**, the URL that is going to be monitored.
     - **method**, the HTTP method that will be used by the monitor.
+    - **header**, client header passed to the request. Remove if you do not want to pass a header.
     - **timeout**, how long we'll wait to consider the request failed. The unit of it is seconds.
     - **expectation**, the list of expectations set for the URL.
         - **HTTP_STATUS**, we will verify if the response status code falls into the expected range. Please keep in mind the range is inclusive on the first number and exclusive on the second number. If just one value is specified, it will default to only the given value, for example `200` will be converted to `200-201`. 

--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -97,6 +97,7 @@ class Configuration(object):
         self.endpoint_url = os.environ.get('ENDPOINT_URL') or self.data['endpoint']['url']
         self.endpoint_url = normalize_url(self.endpoint_url)
         self.endpoint_timeout = os.environ.get('ENDPOINT_TIMEOUT') or self.data['endpoint'].get('timeout') or 1
+        self.endpoint_header = self.data['endpoint'].get('header') or None
         self.allowed_fails = os.environ.get('ALLOWED_FAILS') or self.data['endpoint'].get('allowed_fails') or 0
 
         self.api_url = os.environ.get('CACHET_API_URL') or self.data['cachet']['api_url']
@@ -172,7 +173,10 @@ class Configuration(object):
         according to the expectation results.
         """
         try:
-            self.request = requests.request(self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout)
+            if self.endpoint_header is not None:
+              self.request = requests.request(self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout, headers=self.endpoint_header)
+            else:
+              self.request = requests.request(self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout)
             self.current_timestamp = int(time.time())
         except requests.ConnectionError:
             self.message = 'The URL is unreachable: %s %s' % (self.endpoint_method, self.endpoint_url)

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,8 @@
 endpoint:
   url: http://localhost:8080/swagger
   method: GET
+  header:
+    SOME-HEADER: SOME-VALUE
   timeout: 0.01
   expectation:
     - type: HTTP_STATUS


### PR DESCRIPTION
* Add header option

* Add header option

* Add unit test for headers

* Add client header

* Remove environ for HEADER

environ does not support dictionaries, so HEADER can't be passed.